### PR TITLE
Removes dependency on `freezy-bee/httplug` package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "nette/bootstrap": "^3.0",
-        "freezy-bee/httplug": "^2.0",
         "nyholm/psr7": "^1.1",
         "php-http/guzzle6-adapter": "^2.0",
         "nette/http": "^3.1"
@@ -40,5 +39,10 @@
         "phpstan": "phpstan --ansi --configuration=phpstan.neon analyse src/ tests/",
         "test": "./vendor/bin/tester -C ./tests/",
         "tests": ["@test", "@phpcs", "@phpstan"]
+    },
+    "config": {
+        "platform": {
+            "php": "7.4"
+        }
     }
 }


### PR DESCRIPTION
The package is not used, and is not dependent on it at all

BC Break: Projects that relied on the package being supplied by this project will need to `composer require freezy-bee/httplug`